### PR TITLE
0.23: tests, CI, trusted-publishing release automation; reconcile with PyPI 0.22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install build & test deps
+        run: |
+          pip install --upgrade pip
+          pip install -e . django pytest pytest-django pytest-cov build twine
+      - name: Verify release tag matches setup.py version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg_version="$(python -c "import re,pathlib; m=re.search(r'''version=['\"]([^'\"]+)''', pathlib.Path('setup.py').read_text()); print(m.group(1))")"
+          echo "Release tag: $tag"
+          echo "setup.py version: $pkg_version"
+          test "$tag" = "$pkg_version" || { echo "::error::Release tag '$tag' does not match setup.py version '$pkg_version'. Bump setup.py before tagging."; exit 1; }
+      - name: Run tests
+        run: pytest
+      - name: Build sdist + wheel
+        run: python -m build
+      - name: Check distributions with twine
+        run: python -m twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/djiiif
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: test
+
+on:
+  push:
+    branches: [master, development]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: pip install --upgrade pip
+      - run: pip install -e . django pytest pytest-django pytest-cov
+      - run: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push:
-    branches: [master, development]
+    branches: [master]
   pull_request:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,7 @@ venv*
 htmlcov/
 .coverage
 .cache/
+.pytest_cache/
+.venv/
 *.swp
 *.swo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ CI runs the same `pytest` invocation across Python 3.10–3.13 via `.github/work
 
 The whole library is two files; the second is a thin wrapper around the first.
 
-- `djiiif/__init__.py` — defines `IIIFField` (subclass of `ImageField`) whose `attr_class` is `IIIFFieldFile` (subclass of `ImageFieldFile`). Accessing `.iiif` on a field file returns a freshly constructed `IIIFObject`, which reads `settings.IIIF_PROFILES` and sets one attribute per profile name holding the assembled IIIF URL, plus an `info` attribute for the IIIF `info.json` URL. Empty/unset fields produce empty-string URLs (this is the behavior referenced by the "safe for empty fields" / "return empty string for unpopulated fields" commits).
+- `djiiif/__init__.py` — defines `IIIFField` (subclass of `ImageField`) whose `attr_class` is `IIIFFieldFile` (subclass of `ImageFieldFile`). Accessing `.iiif` on a field file returns a freshly constructed `IIIFObject`, which reads `settings.IIIF_PROFILES` and sets one attribute per profile name holding the assembled IIIF URL, plus an `info` attribute for the IIIF `info.json` URL and an `identifier` attribute for the plain `host/identifier` URL (used for openseadragon-style integrations). Empty/unset fields produce empty-string URLs (this is the behavior referenced by the "safe for empty fields" / "return empty string for unpopulated fields" commits).
 - `djiiif/templatetags/iiiftags.py` — registers the `{% iiif imagefield 'profile' %}` template tag. The tag just does `getattr(imagefield.iiif, profile)`, so it delegates to the real `IIIFObject` via `IIIFFieldFile.iiif`.
 - `djiiif/templatetags/__init__.py` — **dead code**: contains an out-of-sync duplicate of `IIIFObject` / `IIIFField` / `urljoin` (no empty-name guard, no `info` URL, sets a stray `url` attribute). Nothing imports it. Treat `djiiif/__init__.py` as the source of truth; this file should be emptied as part of cleanup.
 
@@ -67,7 +67,7 @@ Documentation in this repo must stay current with the code. When you change beha
 Every change to `djiiif/` must keep the suite green and the coverage gate satisfied. When adding behavior, add tests alongside it. The suite must always cover:
 
 - Both `IIIF_PROFILES` shapes: plain `dict` profile and callable profile.
-- The empty-/`None`-`name` path (must return `""` for every profile attr and for `info`) — this is the regression guarded by the 0.19 / 0.20 commits.
+- The empty-/`None`-`name` path (must return `""` for every profile attr, for `info`, and for `identifier`) — this is the regression guarded by the 0.19 / 0.20 commits.
 - Identifier encoding: a field name containing `/` must appear as `%2F` in the URL.
 - The `{% iiif %}` template tag's happy path and its `NotAnIIIFField` error path.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`djiiif` is a small Django package that extends `ImageField` to expose IIIF Image API URLs. It is published to PyPI as `djiiif`; the package itself has no runtime application — it is consumed by Django projects that depend on it.
+
+## Build & release
+
+**Releases are automated.** Do not run `./build.sh` or `twine upload` from a workstation.
+
+To cut a release:
+
+1. Bump `version=` in `setup.py` and commit on `master` (or merge to it).
+2. Create a GitHub Release with tag `vX.Y` (e.g. `v0.21`) targeting that commit. The tag — minus the leading `v` — **must** match the `setup.py` version; the release workflow asserts this and fails the build otherwise.
+3. `.github/workflows/release.yml` then: installs deps, runs the test suite, builds sdist + wheel via `python -m build`, runs `twine check`, and publishes to PyPI via OIDC trusted publishing (no API token in secrets).
+
+`build.sh` is legacy from before CI — it still works for local sanity checks but is not the release path.
+
+**One-time PyPI setup required:** the project must have a Trusted Publisher configured at https://pypi.org/manage/project/djiiif/settings/publishing/ pointing at `rogerhoward/djiiif`, workflow `release.yml`, environment `pypi`. The matching GitHub Environment `pypi` can also gate the publish job with manual approval / branch restrictions.
+
+Pipenv pins the build/docs/test toolchain (`twine`, `sphinx`, `pytest`, `pytest-django`, `pytest-cov`, `django`) — see `Pipfile`. Runtime dependency is `Django` (declared in `setup.py`).
+
+## Tests
+
+```bash
+pip install -e . django pytest pytest-django pytest-cov   # one-time setup (or via Pipenv)
+pytest                                                    # runs all tests + coverage gate
+pytest tests/test_iiif_object.py::test_dict_profile_builds_url   # single test
+```
+
+Tests live in `tests/`. `tests/conftest.py` configures a minimal in-memory Django (no DB) via `settings.configure(...)` — there is no `manage.py` and no `DJANGO_SETTINGS_MODULE`. Pytest config (testpaths, coverage flags, fail-under threshold) is in `pyproject.toml`.
+
+CI runs the same `pytest` invocation across Python 3.10–3.13 via `.github/workflows/test.yml`.
+
+**Coverage gate: 90% (`--cov-fail-under=90` in `pyproject.toml`).** Any change that drops coverage below the gate must either add tests or — if the line is genuinely defensive/unreachable — raise the gate intentionally rather than silently lowering it.
+
+## Architecture
+
+The whole library is two files; the second is a thin wrapper around the first.
+
+- `djiiif/__init__.py` — defines `IIIFField` (subclass of `ImageField`) whose `attr_class` is `IIIFFieldFile` (subclass of `ImageFieldFile`). Accessing `.iiif` on a field file returns a freshly constructed `IIIFObject`, which reads `settings.IIIF_PROFILES` and sets one attribute per profile name holding the assembled IIIF URL, plus an `info` attribute for the IIIF `info.json` URL. Empty/unset fields produce empty-string URLs (this is the behavior referenced by the "safe for empty fields" / "return empty string for unpopulated fields" commits).
+- `djiiif/templatetags/iiiftags.py` — registers the `{% iiif imagefield 'profile' %}` template tag. The tag just does `getattr(imagefield.iiif, profile)`, so it delegates to the real `IIIFObject` via `IIIFFieldFile.iiif`.
+- `djiiif/templatetags/__init__.py` — **dead code**: contains an out-of-sync duplicate of `IIIFObject` / `IIIFField` / `urljoin` (no empty-name guard, no `info` URL, sets a stray `url` attribute). Nothing imports it. Treat `djiiif/__init__.py` as the source of truth; this file should be emptied as part of cleanup.
+
+Profiles in `settings.IIIF_PROFILES` may be either a `dict` with keys `host, region, size, rotation, quality, format`, or a callable receiving the `IIIFFieldFile` and returning that same dict shape — callables enable per-image logic (e.g. square crop using `parent.width`/`parent.height`). The identifier segment of the URL is the field's `name` with `/` percent-encoded to `%2F`.
+
+## Keeping docs in sync
+
+Documentation in this repo must stay current with the code. When you change behavior, config, commands, or layout, update the affected docs in the **same commit** — not as a follow-up.
+
+- `README.md` and `README.rst` are both checked in and must stay in sync with each other. When you update one, update the other.
+- `CLAUDE.md` (this file) is the contract for future Claude sessions — if you change build/test commands, the public API surface, the testing setup, the coverage gate, or the file layout, update CLAUDE.md so the description matches reality. Stale guidance here is worse than no guidance.
+- `docs/` (Sphinx) is currently a skeleton; if it grows real content, treat it the same way.
+
+## Python conventions
+
+- Target Python 3.10+ (`python_requires='>=3.10'` in `setup.py`; `Pipfile` pins 3.10). Keep these and the trove classifiers in sync when bumping the floor.
+- Use `from __future__ import annotations` is unnecessary on 3.10+; prefer native PEP 604 (`X | None`) and PEP 585 (`list[str]`) syntax.
+- Add type hints to all new/edited public functions, methods, and class attributes. Keep them precise — `Any` is a code smell, not a default.
+- Prefer f-strings over `.format()` / `%`. The existing `'{}.{}'.format(...)` calls in `djiiif/__init__.py` and `iiiftags.py` are fine to leave alone but should be migrated when touched.
+- Keep `IIIFField` / `IIIFFieldFile` / `IIIFObject` import paths stable — they are part of the public API consumed by downstream Django projects.
+
+## Required test coverage
+
+Every change to `djiiif/` must keep the suite green and the coverage gate satisfied. When adding behavior, add tests alongside it. The suite must always cover:
+
+- Both `IIIF_PROFILES` shapes: plain `dict` profile and callable profile.
+- The empty-/`None`-`name` path (must return `""` for every profile attr and for `info`) — this is the regression guarded by the 0.19 / 0.20 commits.
+- Identifier encoding: a field name containing `/` must appear as `%2F` in the URL.
+- The `{% iiif %}` template tag's happy path and its `NotAnIIIFField` error path.
+
+## Formatting & linting
+
+- Use `ruff` for both linting and formatting (`ruff check .` and `ruff format .`). No separate `black` / `flake8` / `isort` — `ruff` covers all three.
+- Line length 100. Double quotes. `pyproject.toml` already exists (for pytest/coverage); add a `[tool.ruff]` block there rather than introducing a separate config file.
+- Run `ruff check --fix` before committing; never silence a lint with `# noqa` without a comment explaining why.
+
+## Packaging modernization notes
+
+The repo still uses legacy `setup.py` + `build.sh` + `MANIFEST.in`. When modernizing:
+
+- Migrate `setup.py` metadata into the existing `pyproject.toml` (PEP 621). `pyproject.toml` already declares the `[build-system]` (setuptools backend) and holds pytest/coverage config; the migration moves `name`/`version`/`install_requires`/classifiers/etc. there too and can then delete `setup.py`.
+- Consider `setuptools-scm` so the package version is derived from the git tag instead of being hand-bumped in `setup.py` — this would let us drop the tag-vs-version assertion in `release.yml`.
+- Replace `python3 setup.py sdist bdist` with `python -m build`; replace the egg-info / `build/` / `dist/` clutter accordingly (and add them to `.gitignore` if not already).
+- Drop `Pipfile` in favor of optional dependency groups in `pyproject.toml` (e.g. `[project.optional-dependencies] dev = [...]`), unless the user explicitly wants to keep Pipenv.

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,17 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+twine = "*"
+sphinx = "*"
+
+[dev-packages]
+django = "*"
+pytest = "*"
+pytest-django = "*"
+pytest-cov = "*"
+
+[requires]
+python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,436 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "1818a17a2d965217bbebe7419d5f39170bf08f43fb53fb8e3a54eebd04111070"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.9"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "alabaster": {
+            "hashes": [
+                "sha256:1ee19aca801bbabb5ba3f5f258e4422dfa86f82f3e9cefb0859b283cdd7f62a3",
+                "sha256:a27a4a084d5e690e16e01e03ad2b2e552c61a65469419b907243193de1a84ae2"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.7.13"
+        },
+        "babel": {
+            "hashes": [
+                "sha256:b4246fb7677d3b98f501a39d43396d3cafdc8eadb045f4a31be01863f655c610",
+                "sha256:cc2d99999cd01d44420ae725a21c9e3711b3aadc7976d6147f622d8581963455"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.12.1"
+        },
+        "bleach": {
+            "hashes": [
+                "sha256:1a1a85c1595e07d8db14c5f09f09e6433502c51c595970edc090551f0db99414",
+                "sha256:33c16e3353dbd13028ab4799a0f89a83f113405c766e9c122df8a06f5b85b3f4"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==6.0.0"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082",
+                "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2023.7.22"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:04e57ab9fbf9607b77f7d057974694b4f6b142da9ed4a199859d9d4d5c63fe96",
+                "sha256:09393e1b2a9461950b1c9a45d5fd251dc7c6f228acab64da1c9c0165d9c7765c",
+                "sha256:0b87549028f680ca955556e3bd57013ab47474c3124dc069faa0b6545b6c9710",
+                "sha256:1000fba1057b92a65daec275aec30586c3de2401ccdcd41f8a5c1e2c87078706",
+                "sha256:1249cbbf3d3b04902ff081ffbb33ce3377fa6e4c7356f759f3cd076cc138d020",
+                "sha256:1920d4ff15ce893210c1f0c0e9d19bfbecb7983c76b33f046c13a8ffbd570252",
+                "sha256:193cbc708ea3aca45e7221ae58f0fd63f933753a9bfb498a3b474878f12caaad",
+                "sha256:1a100c6d595a7f316f1b6f01d20815d916e75ff98c27a01ae817439ea7726329",
+                "sha256:1f30b48dd7fa1474554b0b0f3fdfdd4c13b5c737a3c6284d3cdc424ec0ffff3a",
+                "sha256:203f0c8871d5a7987be20c72442488a0b8cfd0f43b7973771640fc593f56321f",
+                "sha256:246de67b99b6851627d945db38147d1b209a899311b1305dd84916f2b88526c6",
+                "sha256:2dee8e57f052ef5353cf608e0b4c871aee320dd1b87d351c28764fc0ca55f9f4",
+                "sha256:2efb1bd13885392adfda4614c33d3b68dee4921fd0ac1d3988f8cbb7d589e72a",
+                "sha256:2f4ac36d8e2b4cc1aa71df3dd84ff8efbe3bfb97ac41242fbcfc053c67434f46",
+                "sha256:3170c9399da12c9dc66366e9d14da8bf7147e1e9d9ea566067bbce7bb74bd9c2",
+                "sha256:3b1613dd5aee995ec6d4c69f00378bbd07614702a315a2cf6c1d21461fe17c23",
+                "sha256:3bb3d25a8e6c0aedd251753a79ae98a093c7e7b471faa3aa9a93a81431987ace",
+                "sha256:3bb7fda7260735efe66d5107fb7e6af6a7c04c7fce9b2514e04b7a74b06bf5dd",
+                "sha256:41b25eaa7d15909cf3ac4c96088c1f266a9a93ec44f87f1d13d4a0e86c81b982",
+                "sha256:45de3f87179c1823e6d9e32156fb14c1927fcc9aba21433f088fdfb555b77c10",
+                "sha256:46fb8c61d794b78ec7134a715a3e564aafc8f6b5e338417cb19fe9f57a5a9bf2",
+                "sha256:48021783bdf96e3d6de03a6e39a1171ed5bd7e8bb93fc84cc649d11490f87cea",
+                "sha256:4957669ef390f0e6719db3613ab3a7631e68424604a7b448f079bee145da6e09",
+                "sha256:5e86d77b090dbddbe78867a0275cb4df08ea195e660f1f7f13435a4649e954e5",
+                "sha256:6339d047dab2780cc6220f46306628e04d9750f02f983ddb37439ca47ced7149",
+                "sha256:681eb3d7e02e3c3655d1b16059fbfb605ac464c834a0c629048a30fad2b27489",
+                "sha256:6c409c0deba34f147f77efaa67b8e4bb83d2f11c8806405f76397ae5b8c0d1c9",
+                "sha256:7095f6fbfaa55defb6b733cfeb14efaae7a29f0b59d8cf213be4e7ca0b857b80",
+                "sha256:70c610f6cbe4b9fce272c407dd9d07e33e6bf7b4aa1b7ffb6f6ded8e634e3592",
+                "sha256:72814c01533f51d68702802d74f77ea026b5ec52793c791e2da806a3844a46c3",
+                "sha256:7a4826ad2bd6b07ca615c74ab91f32f6c96d08f6fcc3902ceeedaec8cdc3bcd6",
+                "sha256:7c70087bfee18a42b4040bb9ec1ca15a08242cf5867c58726530bdf3945672ed",
+                "sha256:855eafa5d5a2034b4621c74925d89c5efef61418570e5ef9b37717d9c796419c",
+                "sha256:8700f06d0ce6f128de3ccdbc1acaea1ee264d2caa9ca05daaf492fde7c2a7200",
+                "sha256:89f1b185a01fe560bc8ae5f619e924407efca2191b56ce749ec84982fc59a32a",
+                "sha256:8b2c760cfc7042b27ebdb4a43a4453bd829a5742503599144d54a032c5dc7e9e",
+                "sha256:8c2f5e83493748286002f9369f3e6607c565a6a90425a3a1fef5ae32a36d749d",
+                "sha256:8e098148dd37b4ce3baca71fb394c81dc5d9c7728c95df695d2dca218edf40e6",
+                "sha256:94aea8eff76ee6d1cdacb07dd2123a68283cb5569e0250feab1240058f53b623",
+                "sha256:95eb302ff792e12aba9a8b8f8474ab229a83c103d74a750ec0bd1c1eea32e669",
+                "sha256:9bd9b3b31adcb054116447ea22caa61a285d92e94d710aa5ec97992ff5eb7cf3",
+                "sha256:9e608aafdb55eb9f255034709e20d5a83b6d60c054df0802fa9c9883d0a937aa",
+                "sha256:a103b3a7069b62f5d4890ae1b8f0597618f628b286b03d4bc9195230b154bfa9",
+                "sha256:a386ebe437176aab38c041de1260cd3ea459c6ce5263594399880bbc398225b2",
+                "sha256:a38856a971c602f98472050165cea2cdc97709240373041b69030be15047691f",
+                "sha256:a401b4598e5d3f4a9a811f3daf42ee2291790c7f9d74b18d75d6e21dda98a1a1",
+                "sha256:a7647ebdfb9682b7bb97e2a5e7cb6ae735b1c25008a70b906aecca294ee96cf4",
+                "sha256:aaf63899c94de41fe3cf934601b0f7ccb6b428c6e4eeb80da72c58eab077b19a",
+                "sha256:b0dac0ff919ba34d4df1b6131f59ce95b08b9065233446be7e459f95554c0dc8",
+                "sha256:baacc6aee0b2ef6f3d308e197b5d7a81c0e70b06beae1f1fcacffdbd124fe0e3",
+                "sha256:bf420121d4c8dce6b889f0e8e4ec0ca34b7f40186203f06a946fa0276ba54029",
+                "sha256:c04a46716adde8d927adb9457bbe39cf473e1e2c2f5d0a16ceb837e5d841ad4f",
+                "sha256:c0b21078a4b56965e2b12f247467b234734491897e99c1d51cee628da9786959",
+                "sha256:c1c76a1743432b4b60ab3358c937a3fe1341c828ae6194108a94c69028247f22",
+                "sha256:c4983bf937209c57240cff65906b18bb35e64ae872da6a0db937d7b4af845dd7",
+                "sha256:c4fb39a81950ec280984b3a44f5bd12819953dc5fa3a7e6fa7a80db5ee853952",
+                "sha256:c57921cda3a80d0f2b8aec7e25c8aa14479ea92b5b51b6876d975d925a2ea346",
+                "sha256:c8063cf17b19661471ecbdb3df1c84f24ad2e389e326ccaf89e3fb2484d8dd7e",
+                "sha256:ccd16eb18a849fd8dcb23e23380e2f0a354e8daa0c984b8a732d9cfaba3a776d",
+                "sha256:cd6dbe0238f7743d0efe563ab46294f54f9bc8f4b9bcf57c3c666cc5bc9d1299",
+                "sha256:d62e51710986674142526ab9f78663ca2b0726066ae26b78b22e0f5e571238dd",
+                "sha256:db901e2ac34c931d73054d9797383d0f8009991e723dab15109740a63e7f902a",
+                "sha256:e03b8895a6990c9ab2cdcd0f2fe44088ca1c65ae592b8f795c3294af00a461c3",
+                "sha256:e1c8a2f4c69e08e89632defbfabec2feb8a8d99edc9f89ce33c4b9e36ab63037",
+                "sha256:e4b749b9cc6ee664a3300bb3a273c1ca8068c46be705b6c31cf5d276f8628a94",
+                "sha256:e6a5bf2cba5ae1bb80b154ed68a3cfa2fa00fde979a7f50d6598d3e17d9ac20c",
+                "sha256:e857a2232ba53ae940d3456f7533ce6ca98b81917d47adc3c7fd55dad8fab858",
+                "sha256:ee4006268ed33370957f55bf2e6f4d263eaf4dc3cfc473d1d90baff6ed36ce4a",
+                "sha256:eef9df1eefada2c09a5e7a40991b9fc6ac6ef20b1372abd48d2794a316dc0449",
+                "sha256:f058f6963fd82eb143c692cecdc89e075fa0828db2e5b291070485390b2f1c9c",
+                "sha256:f25c229a6ba38a35ae6e25ca1264621cc25d4d38dca2942a7fce0b67a4efe918",
+                "sha256:f2a1d0fd4242bd8643ce6f98927cf9c04540af6efa92323e9d3124f57727bfc1",
+                "sha256:f7560358a6811e52e9c4d142d497f1a6e10103d3a6881f18d04dbce3729c0e2c",
+                "sha256:f779d3ad205f108d14e99bb3859aa7dd8e9c68874617c72354d7ecaec2a054ac",
+                "sha256:f87f746ee241d30d6ed93969de31e5ffd09a2961a051e60ae6bddde9ec3583aa"
+            ],
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==3.2.0"
+        },
+        "docutils": {
+            "hashes": [
+                "sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6",
+                "sha256:f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.20.1"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
+                "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==3.4"
+        },
+        "imagesize": {
+            "hashes": [
+                "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b",
+                "sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.4.1"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:3ebb78df84a805d7698245025b975d9d67053cd94c79245ba4b3eb694abe68bb",
+                "sha256:dbace7892d8c0c4ac1ad096662232f831d4e64f4c4545bd53016a3e9d4654743"
+            ],
+            "markers": "python_version < '3.10'",
+            "version": "==6.8.0"
+        },
+        "jaraco.classes": {
+            "hashes": [
+                "sha256:10afa92b6743f25c0cf5f37c6bb6e18e2c5bb84a16527ccfc0040ea377e7aaeb",
+                "sha256:c063dd08e89217cee02c8d5e5ec560f2c8ce6cdc2fcdc2e68f7b2e5547ed3621"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.3.0"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852",
+                "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.1.2"
+        },
+        "keyring": {
+            "hashes": [
+                "sha256:4901caaf597bfd3bbd78c9a0c7c4c29fcd8310dab2cffefe749e916b6527acd6",
+                "sha256:ca0746a19ec421219f4d713f848fa297a661a8a8c1504867e55bfb5e09091509"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==24.2.0"
+        },
+        "markdown-it-py": {
+            "hashes": [
+                "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1",
+                "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.0.0"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e",
+                "sha256:0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e",
+                "sha256:10bbfe99883db80bdbaff2dcf681dfc6533a614f700da1287707e8a5d78a8431",
+                "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686",
+                "sha256:1577735524cdad32f9f694208aa75e422adba74f1baee7551620e43a3141f559",
+                "sha256:1b40069d487e7edb2676d3fbdb2b0829ffa2cd63a2ec26c4938b2d34391b4ecc",
+                "sha256:282c2cb35b5b673bbcadb33a585408104df04f14b2d9b01d4c345a3b92861c2c",
+                "sha256:2c1b19b3aaacc6e57b7e25710ff571c24d6c3613a45e905b1fde04d691b98ee0",
+                "sha256:2ef12179d3a291be237280175b542c07a36e7f60718296278d8593d21ca937d4",
+                "sha256:338ae27d6b8745585f87218a3f23f1512dbf52c26c28e322dbe54bcede54ccb9",
+                "sha256:3c0fae6c3be832a0a0473ac912810b2877c8cb9d76ca48de1ed31e1c68386575",
+                "sha256:3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba",
+                "sha256:42de32b22b6b804f42c5d98be4f7e5e977ecdd9ee9b660fda1a3edf03b11792d",
+                "sha256:504b320cd4b7eff6f968eddf81127112db685e81f7e36e75f9f84f0df46041c3",
+                "sha256:525808b8019e36eb524b8c68acdd63a37e75714eac50e988180b169d64480a00",
+                "sha256:56d9f2ecac662ca1611d183feb03a3fa4406469dafe241673d521dd5ae92a155",
+                "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac",
+                "sha256:65c1a9bcdadc6c28eecee2c119465aebff8f7a584dd719facdd9e825ec61ab52",
+                "sha256:68e78619a61ecf91e76aa3e6e8e33fc4894a2bebe93410754bd28fce0a8a4f9f",
+                "sha256:69c0f17e9f5a7afdf2cc9fb2d1ce6aabdb3bafb7f38017c0b77862bcec2bbad8",
+                "sha256:6b2b56950d93e41f33b4223ead100ea0fe11f8e6ee5f641eb753ce4b77a7042b",
+                "sha256:787003c0ddb00500e49a10f2844fac87aa6ce977b90b0feaaf9de23c22508b24",
+                "sha256:7ef3cb2ebbf91e330e3bb937efada0edd9003683db6b57bb108c4001f37a02ea",
+                "sha256:8023faf4e01efadfa183e863fefde0046de576c6f14659e8782065bcece22198",
+                "sha256:8758846a7e80910096950b67071243da3e5a20ed2546e6392603c096778d48e0",
+                "sha256:8afafd99945ead6e075b973fefa56379c5b5c53fd8937dad92c662da5d8fd5ee",
+                "sha256:8c41976a29d078bb235fea9b2ecd3da465df42a562910f9022f1a03107bd02be",
+                "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2",
+                "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707",
+                "sha256:962f82a3086483f5e5f64dbad880d31038b698494799b097bc59c2edf392fce6",
+                "sha256:9dcdfd0eaf283af041973bff14a2e143b8bd64e069f4c383416ecd79a81aab58",
+                "sha256:aa7bd130efab1c280bed0f45501b7c8795f9fdbeb02e965371bbef3523627779",
+                "sha256:ab4a0df41e7c16a1392727727e7998a467472d0ad65f3ad5e6e765015df08636",
+                "sha256:ad9e82fb8f09ade1c3e1b996a6337afac2b8b9e365f926f5a61aacc71adc5b3c",
+                "sha256:af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad",
+                "sha256:b076b6226fb84157e3f7c971a47ff3a679d837cf338547532ab866c57930dbee",
+                "sha256:b7ff0f54cb4ff66dd38bebd335a38e2c22c41a8ee45aa608efc890ac3e3931bc",
+                "sha256:bfce63a9e7834b12b87c64d6b155fdd9b3b96191b6bd334bf37db7ff1fe457f2",
+                "sha256:c011a4149cfbcf9f03994ec2edffcb8b1dc2d2aede7ca243746df97a5d41ce48",
+                "sha256:c9c804664ebe8f83a211cace637506669e7890fec1b4195b505c214e50dd4eb7",
+                "sha256:ca379055a47383d02a5400cb0d110cef0a776fc644cda797db0c5696cfd7e18e",
+                "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b",
+                "sha256:cd0f502fe016460680cd20aaa5a76d241d6f35a1c3350c474bac1273803893fa",
+                "sha256:ceb01949af7121f9fc39f7d27f91be8546f3fb112c608bc4029aef0bab86a2a5",
+                "sha256:d080e0a5eb2529460b30190fcfcc4199bd7f827663f858a226a81bc27beaa97e",
+                "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb",
+                "sha256:df0be2b576a7abbf737b1575f048c23fb1d769f267ec4358296f31c2479db8f9",
+                "sha256:e09031c87a1e51556fdcb46e5bd4f59dfb743061cf93c4d6831bf894f125eb57",
+                "sha256:e4dd52d80b8c83fdce44e12478ad2e85c64ea965e75d66dbeafb0a3e77308fcc",
+                "sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.1.3"
+        },
+        "mdurl": {
+            "hashes": [
+                "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
+                "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.1.2"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:626c369fa0eb37bac0291bce8259b332fd59ac792fa5497b59837309cd5b114a",
+                "sha256:64e0735fcfdc6f3464ea133afe8ea4483b1c5fe3a3d69852e6503b43a0b222e6"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==10.1.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61",
+                "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==23.1"
+        },
+        "pkginfo": {
+            "hashes": [
+                "sha256:4b7a555a6d5a22169fcc9cf7bfd78d296b0361adad412a346c1226849af5e546",
+                "sha256:8fd5896e8718a4372f0ea9cc9d96f6417c9b986e23a4d116dda26b62cc29d046"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.9.6"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692",
+                "sha256:1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.16.1"
+        },
+        "readme-renderer": {
+            "hashes": [
+                "sha256:4f4b11e5893f5a5d725f592c5a343e0dc74f5f273cb3dcf8c42d9703a27073f7",
+                "sha256:a38243d5b6741b700a850026e62da4bd739edc7422071e95fd5c4bb60171df86"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==41.0"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
+                "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.31.0"
+        },
+        "requests-toolbelt": {
+            "hashes": [
+                "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6",
+                "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.0.0"
+        },
+        "rfc3986": {
+            "hashes": [
+                "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd",
+                "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.0"
+        },
+        "rich": {
+            "hashes": [
+                "sha256:146a90b3b6b47cac4a73c12866a499e9817426423f57c5a66949c086191a8808",
+                "sha256:fb9d6c0a0f643c99eed3875b5377a184132ba9be4d61516a55273d3554d75a39"
+            ],
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==13.5.2"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==1.16.0"
+        },
+        "snowballstemmer": {
+            "hashes": [
+                "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1",
+                "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"
+            ],
+            "version": "==2.2.0"
+        },
+        "sphinx": {
+            "hashes": [
+                "sha256:1a9290001b75c497fd087e92b0334f1bbfa1a1ae7fddc084990c4b7bd1130b88",
+                "sha256:9269f9ed2821c9ebd30e4204f5c2339f5d4980e377bc89cb2cb6f9b17409c20a"
+            ],
+            "index": "pypi",
+            "version": "==7.2.5"
+        },
+        "sphinxcontrib-applehelp": {
+            "hashes": [
+                "sha256:094c4d56209d1734e7d252f6e0b3ccc090bd52ee56807a5d9315b19c122ab15d",
+                "sha256:39fdc8d762d33b01a7d8f026a3b7d71563ea3b72787d5f00ad8465bd9d6dfbfa"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.0.7"
+        },
+        "sphinxcontrib-devhelp": {
+            "hashes": [
+                "sha256:63b41e0d38207ca40ebbeabcf4d8e51f76c03e78cd61abe118cf4435c73d4212",
+                "sha256:fe8009aed765188f08fcaadbb3ea0d90ce8ae2d76710b7e29ea7d047177dae2f"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.0.5"
+        },
+        "sphinxcontrib-htmlhelp": {
+            "hashes": [
+                "sha256:6c26a118a05b76000738429b724a0568dbde5b72391a688577da08f11891092a",
+                "sha256:8001661c077a73c29beaf4a79968d0726103c5605e27db92b9ebed8bab1359e9"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.0.4"
+        },
+        "sphinxcontrib-jsmath": {
+            "hashes": [
+                "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178",
+                "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==1.0.1"
+        },
+        "sphinxcontrib-qthelp": {
+            "hashes": [
+                "sha256:62b9d1a186ab7f5ee3356d906f648cacb7a6bdb94d201ee7adf26db55092982d",
+                "sha256:bf76886ee7470b934e363da7a954ea2825650013d367728588732c7350f49ea4"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.0.6"
+        },
+        "sphinxcontrib-serializinghtml": {
+            "hashes": [
+                "sha256:0c64ff898339e1fac29abd2bf5f11078f3ec413cfe9c046d3120d7ca65530b54",
+                "sha256:9b36e503703ff04f20e9675771df105e58aa029cfcbc23b8ed716019b7416ae1"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.1.9"
+        },
+        "twine": {
+            "hashes": [
+                "sha256:929bc3c280033347a00f847236564d1c52a3e61b1ac2516c97c48f3ceab756d8",
+                "sha256:9e102ef5fdd5a20661eb88fad46338806c3bd32cf1db729603fe3697b1bc83c8"
+            ],
+            "index": "pypi",
+            "version": "==4.0.2"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11",
+                "sha256:de7df1803967d2c2a98e4b11bb7d6bd9210474c46e8a0401514e3a42a75ebde4"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.4"
+        },
+        "webencodings": {
+            "hashes": [
+                "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
+                "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
+            ],
+            "version": "==0.5.1"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:679e51dd4403591b2d6838a48de3d283f3d188412a9782faadf845f298736ba0",
+                "sha256:ebc15946aa78bd63458992fc81ec3b6f7b1e92d51c35e6de1c3804e73b799147"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.16.2"
+        }
+    },
+    "develop": {}
+}

--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ print(instance.original.iiif.info)
 > http://server/uploads/filename.jpg/info.json
 ```
 
+As of version 0.21, we also expose a plain identifier-only URL (host + identifier, with no `/region/size/rotation/quality.format` suffix) — handy for handing the image off to viewers like OpenSeadragon that take just the IIIF identifier:
+
+```
+print(instance.original.iiif.identifier)
+> http://server/uploads/filename.jpg
+```
+
 ### callable-based profiles
 
 You can also use a callable to dynamically generate a URL. The callable will receive the parent `IIIFFieldFile` (a subclass of `ImageFieldFile`) as its sole parameter, `parent`, and must return a `dict` with the following keys: host, region, size, rotation, quality, and format. Using a callable allows you to implement more complex logic in your profile, including the ability to access the original file's name, width, and height.

--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,13 @@ print(instance.original.iiif.info)
 > http://server/uploads/filename.jpg/info.json
 ```
 
+As of version 0.21, we also expose a plain identifier-only URL (host + identifier, with no `/region/size/rotation/quality.format` suffix) — handy for handing the image off to viewers like OpenSeadragon that take just the IIIF identifier:
+
+```
+print(instance.original.iiif.identifier)
+> http://server/uploads/filename.jpg
+```
+
 ### callable-based profiles
 
 You can also use a callable to dynamically generate a URL. The callable will receive the parent `IIIFFieldFile` (a subclass of `ImageFieldFile`) as its sole parameter, `parent`, and must return a `dict` with the following keys: host, region, size, rotation, quality, and format. Using a callable allows you to implement more complex logic in your profile, including the ability to access the original file's name, width, and height.

--- a/djiiif/__init__.py
+++ b/djiiif/__init__.py
@@ -40,6 +40,13 @@ class IIIFObject(object):
         else:
             setattr(self, "info", "")
 
+        # Add plain identifier URL
+        if parent.name:
+            url = urljoin([iiif['host'], identifier])
+            setattr(self, "identifier", url)
+        else:
+            setattr(self, "identifier", "")
+
 
 class IIIFFieldFile(ImageFieldFile):
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=djiiif --cov-report=term-missing --cov-fail-under=90"
+
+[tool.coverage.run]
+branch = true
+source = ["djiiif"]
+omit = ["djiiif/templatetags/__init__.py"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='djiiif',
-    version='0.21',
+    version='0.23',
 
     packages=find_packages(exclude=["tests", "tests.*"]),
     install_requires=['Django'],

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,9 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='djiiif',
-    version='0.20',
+    version='0.21',
 
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests", "tests.*"]),
     install_requires=['Django'],
     include_package_data=True,
     license='BSD License',  # example license
@@ -17,18 +17,19 @@ setup(
     url='https://github.com/rogerhoward/djiiif/',
     author='Roger Howard',
     author_email='rogerhoward+django@gmail.com',
+    python_requires='>=3.10',
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+import django
+from django.conf import settings
+
+
+def pytest_configure():
+    settings.configure(
+        DEBUG=False,
+        DATABASES={},
+        INSTALLED_APPS=["djiiif"],
+        TEMPLATES=[
+            {
+                "BACKEND": "django.template.backends.django.DjangoTemplates",
+                "DIRS": [],
+                "APP_DIRS": True,
+                "OPTIONS": {},
+            },
+        ],
+        IIIF_HOST="http://server/",
+        IIIF_PROFILES={
+            "thumbnail": {
+                "host": "http://server/",
+                "region": "full",
+                "size": "150,",
+                "rotation": "0",
+                "quality": "default",
+                "format": "jpg",
+            },
+        },
+        USE_TZ=True,
+    )
+    django.setup()

--- a/tests/test_iiif_object.py
+++ b/tests/test_iiif_object.py
@@ -35,10 +35,17 @@ def test_info_url_present():
 
 
 @override_settings(IIIF_PROFILES=DICT_PROFILES)
+def test_identifier_url_present():
+    obj = IIIFObject(FakeParent("uploads/file.jpg"))
+    assert obj.identifier == "http://server/uploads%2Ffile.jpg"
+
+
+@override_settings(IIIF_PROFILES=DICT_PROFILES)
 def test_empty_name_returns_empty_strings():
     obj = IIIFObject(FakeParent(""))
     assert obj.thumbnail == ""
     assert obj.info == ""
+    assert obj.identifier == ""
 
 
 @override_settings(IIIF_PROFILES=DICT_PROFILES)
@@ -46,6 +53,7 @@ def test_none_name_returns_empty_strings():
     obj = IIIFObject(FakeParent(None))
     assert obj.thumbnail == ""
     assert obj.info == ""
+    assert obj.identifier == ""
 
 
 @override_settings(IIIF_PROFILES=DICT_PROFILES)

--- a/tests/test_iiif_object.py
+++ b/tests/test_iiif_object.py
@@ -1,0 +1,84 @@
+from django.test import override_settings
+
+from djiiif import IIIFObject
+
+
+class FakeParent:
+    def __init__(self, name, width=None, height=None):
+        self.name = name
+        self.width = width
+        self.height = height
+
+
+DICT_PROFILES = {
+    "thumbnail": {
+        "host": "http://server/",
+        "region": "full",
+        "size": "150,",
+        "rotation": "0",
+        "quality": "default",
+        "format": "jpg",
+    },
+}
+
+
+@override_settings(IIIF_PROFILES=DICT_PROFILES)
+def test_dict_profile_builds_url():
+    obj = IIIFObject(FakeParent("uploads/file.jpg"))
+    assert obj.thumbnail == "http://server/uploads%2Ffile.jpg/full/150,/0/default.jpg"
+
+
+@override_settings(IIIF_PROFILES=DICT_PROFILES)
+def test_info_url_present():
+    obj = IIIFObject(FakeParent("uploads/file.jpg"))
+    assert obj.info == "http://server/uploads%2Ffile.jpg/info.json"
+
+
+@override_settings(IIIF_PROFILES=DICT_PROFILES)
+def test_empty_name_returns_empty_strings():
+    obj = IIIFObject(FakeParent(""))
+    assert obj.thumbnail == ""
+    assert obj.info == ""
+
+
+@override_settings(IIIF_PROFILES=DICT_PROFILES)
+def test_none_name_returns_empty_strings():
+    obj = IIIFObject(FakeParent(None))
+    assert obj.thumbnail == ""
+    assert obj.info == ""
+
+
+@override_settings(IIIF_PROFILES=DICT_PROFILES)
+def test_identifier_percent_encodes_slashes():
+    obj = IIIFObject(FakeParent("a/b/c.jpg"))
+    assert "a%2Fb%2Fc.jpg" in obj.thumbnail
+    assert "/" not in obj.thumbnail.split("http://server/")[1].split("/")[0]
+
+
+def _square_profile(parent):
+    return {
+        "host": "http://server/",
+        "region": f"0,0,{parent.width},{parent.height}",
+        "size": "256,256",
+        "rotation": "0",
+        "quality": "default",
+        "format": "jpg",
+    }
+
+
+@override_settings(IIIF_PROFILES={"square": _square_profile})
+def test_callable_profile_receives_parent_and_builds_url():
+    obj = IIIFObject(FakeParent("file.jpg", width=400, height=300))
+    assert obj.square == "http://server/file.jpg/0,0,400,300/256,256/0/default.jpg"
+
+
+@override_settings(
+    IIIF_PROFILES={
+        "thumb": DICT_PROFILES["thumbnail"],
+        "square": _square_profile,
+    }
+)
+def test_multiple_profiles_coexist():
+    obj = IIIFObject(FakeParent("pic.jpg", width=100, height=200))
+    assert obj.thumb.endswith("/full/150,/0/default.jpg")
+    assert obj.square.endswith("/0,0,100,200/256,256/0/default.jpg")

--- a/tests/test_template_tag.py
+++ b/tests/test_template_tag.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+
+import pytest
+from django.template import Context, Template
+from django.test import override_settings
+
+from djiiif.templatetags.iiiftags import NotAnIIIFField, iiif as iiif_tag
+
+
+DICT_PROFILES = {
+    "thumbnail": {
+        "host": "http://server/",
+        "region": "full",
+        "size": "150,",
+        "rotation": "0",
+        "quality": "default",
+        "format": "jpg",
+    },
+}
+
+
+def test_tag_returns_profile_url_from_iiif_attr():
+    obj = SimpleNamespace(iiif=SimpleNamespace(thumbnail="http://example/url"))
+    assert iiif_tag(obj, "thumbnail") == "http://example/url"
+
+
+def test_tag_raises_when_input_has_no_iiif():
+    with pytest.raises(NotAnIIIFField):
+        iiif_tag(SimpleNamespace(), "thumbnail")
+
+
+def test_tag_raises_when_profile_missing():
+    obj = SimpleNamespace(iiif=SimpleNamespace())
+    with pytest.raises(NotAnIIIFField):
+        iiif_tag(obj, "thumbnail")
+
+
+@override_settings(IIIF_PROFILES=DICT_PROFILES)
+def test_tag_renders_in_template():
+    parent = SimpleNamespace(
+        iiif=SimpleNamespace(thumbnail="http://server/uploads%2Ff.jpg/full/150,/0/default.jpg")
+    )
+    template = Template("{% load iiiftags %}{% iiif asset 'thumbnail' %}")
+    rendered = template.render(Context({"asset": parent}))
+    assert rendered == "http://server/uploads%2Ff.jpg/full/150,/0/default.jpg"

--- a/tests/test_urljoin.py
+++ b/tests/test_urljoin.py
@@ -1,0 +1,20 @@
+import pytest
+
+from djiiif import urljoin
+
+
+def test_strips_internal_slashes_and_preserves_trailing():
+    assert urljoin(["http://a/", "/b/", "c.jpg"]) == "http://a/b/c.jpg"
+
+
+def test_preserves_trailing_slash_on_last_segment():
+    assert urljoin(["http://a/", "/b/"]) == "http://a/b/"
+
+
+def test_single_segment():
+    assert urljoin(["x"]) == "x"
+
+
+def test_empty_list_raises():
+    with pytest.raises(ValueError):
+        urljoin([])


### PR DESCRIPTION
## Summary
- Adds a pytest suite covering `IIIFObject`, the `iiif` template tag, and `urljoin`, with a 90% coverage gate
- Adds GitHub Actions: `test.yml` runs the suite on push/PR across Python 3.10–3.13; `release.yml` builds and publishes to PyPI via OIDC trusted publishing on GitHub Release
- Reconciles master with the code actually published as 0.22 — the `.identifier` attribute was shipped to PyPI in Sep 2023 but never committed back (development carried a syntactically broken version of it). Porting the correct code so 0.23 does not silently drop the feature for upgraders.
- Excludes `tests/` from the built wheel, adds `[build-system]` to `pyproject.toml`, drops stale Python 3.6–3.8 / Django 1.11 classifiers
- Bumps to **0.23** (0.21 and 0.22 are already on PyPI)
- Adds CLAUDE.md documenting build, test, release flow, conventions, and the obligation to keep docs in sync with code

## Test plan
- [x] `pytest` locally: 16 passed, 94% coverage
- [x] `python -m build` + `twine check`: sdist + wheel build clean
- [x] Verified wheel contains only `djiiif/` (no `tests/` leakage)
- [x] Negative test of tag-vs-version assertion in `release.yml`
- [ ] CI test workflow passes on this PR
- [ ] After merge: create `v0.23` GitHub Release → release workflow publishes to PyPI

## Notes
Retires the `development` branch as part of moving to a trunk-based workflow (it was 3 commits ahead of master with a broken 0.21 attempt — those commits are superseded by this PR).