### PR TITLE
Land Tier-3 work (as_dict, manifest view, DRF field) missed by #24's stacked merge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,5 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
       - run: pip install --upgrade pip
-      - run: pip install -e . django pytest pytest-django pytest-cov
+      - run: pip install -e ".[drf]" django pytest pytest-django pytest-cov
       - run: pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,16 @@ dates are the commit dates of the corresponding version bump.
   IIIF 3.0 defaults (`size="max"`) and `mirror` / `upscale` flags that fold into
   the `!`-rotation and `^`-size prefixes. Callable profiles may now return a
   `Profile` as well as a `dict`.
-- Drop-in `info.json` serving view (`djiiif.views.serve_info_json`) and URLconf
-  (`djiiif.urls`): `path("iiif/", include("djiiif.urls"))` serves `info.json` for
-  stored images with the correct content type and CORS header — no separate image
-  server required for the metadata document.
+- Drop-in serving views (`djiiif.views.serve_info_json` / `serve_manifest`) and
+  URLconf (`djiiif.urls`): `path("iiif/", include("djiiif.urls"))` serves both
+  `info.json` and `manifest` for stored images with the correct content type and
+  CORS header — no separate image server required for the metadata documents.
+- `iiif.as_dict()`: returns every profile URL keyed by profile name (with an
+  `include_meta=True` option to add the `info`/`identifier` URLs) — convenient for
+  templates and JSON responses.
+- Optional Django REST Framework support: `djiiif.serializers.IIIFSerializerField`
+  serializes an `IIIFField` to its `as_dict()` mapping. Install via the new `drf`
+  extra (`pip install djiiif[drf]`); importing `djiiif` never imports DRF.
 - System check `check_iiif_profiles` (registered by the new `DjiiifConfig` app
   config): `manage.py check` now validates `IIIF_PROFILES` at startup, flagging a
   non-`dict` setting or a `dict` profile missing required keys.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Pipenv pins the build/docs/test toolchain (`twine`, `sphinx`, `pytest`, `pytest-
 ## Tests
 
 ```bash
-pip install -e . django pytest pytest-django pytest-cov   # one-time setup (or via Pipenv)
+pip install -e ".[drf]" django pytest pytest-django pytest-cov   # one-time setup (or via Pipenv); [drf] enables the DRF serializer tests
 pytest                                                    # runs all tests + coverage gate
 pytest tests/test_iiif_object.py::test_dict_profile_builds_url   # single test
 ```
@@ -61,7 +61,9 @@ The core is `djiiif/__init__.py`; the other modules are thin, optional add-ons a
   - **Module-level builders** (all public, all reused by the serving view): `encode_identifier(name)` percent-encodes the identifier segment; `resolve_profile(profile, parent)` normalizes any profile shape to a spec `dict`; `image_url(spec, identifier)` assembles the Image API URL; `build_info_document(...)` and `build_manifest(...)` construct the two JSON documents; `_api_version`/`_compliance_level` resolve the version/level settings. `IIIF_CONTEXTS` maps Image API version → `@context` URI; `PRESENTATION_CONTEXT` is the Presentation 3.0 context; `PROFILE_KEYS` is the required-key tuple.
   - `Profile` (frozen dataclass, added 0.24) is the typed, opt-in profile shape with 3.0 defaults (`size="max"`) and `mirror`/`upscale` flags that fold into the `!`-rotation / `^`-size prefixes via `.as_spec()`.
   - `IIIFObject.info_document` and `IIIFObject.manifest` (both `cached_property`, 0.24) are distinct from the eager URL attributes: they return **documents** (`dict`, or `None` for an empty field) built from the image's own `width`/`height`. They are the *only* attributes that read the file from storage, so constructing an `IIIFObject` stays I/O-free (the constructor stores `self._parent` for them). Both honor `IIIF_IMAGE_API_VERSION` (default `3`; `2` switches to 2.x shapes) and `IIIF_COMPLIANCE_LEVEL` (default `"level2"`); an unknown version raises `ImproperlyConfigured`.
-- `djiiif/views.py` + `djiiif/urls.py` (0.24) — optional drop-in `serve_info_json` view and its URLconf. Maps an encoded identifier back to a stored image via `default_storage`, reads dimensions with `get_image_dimensions`, and returns `build_info_document(...)` as `application/ld+json` with a `*` CORS header; the document `id` comes from the request URL. Included via `path("iiif/", include("djiiif.urls"))`; uses default storage only.
+  - `IIIFObject.as_dict(include_meta=False)` returns `{profile_name: url}` for every configured profile (optionally adding `info`/`identifier`), using the `self._profile_names` captured at construction. Backs the DRF serializer and template iteration.
+- `djiiif/views.py` + `djiiif/urls.py` (0.24) — optional drop-in `serve_info_json` / `serve_manifest` views and their URLconf. Each maps an encoded identifier back to a stored image via `default_storage` (shared `_load_dimensions` helper reads dimensions with `get_image_dimensions`), and returns `build_info_document(...)` / `build_manifest(...)` as `application/ld+json` with a `*` CORS header (shared `_ld_json` helper); the document `id` comes from the request URL. Included via `path("iiif/", include("djiiif.urls"))`; uses default storage only.
+- `djiiif/serializers.py` (0.24) — **optional** DRF field `IIIFSerializerField` (read-only; `to_representation` returns `iiif.as_dict(...)`). Imports `rest_framework`, so it is an extra (`pip install djiiif[drf]`, `extras_require` in `setup.py`) and is **never imported by `djiiif/__init__.py`** — the core package has no DRF dependency. It is omitted from the coverage source (its tests `importorskip` DRF and CI installs the `drf` extra to run them).
 - `djiiif/checks.py` + `djiiif/apps.py` (0.24) — `DjiiifConfig.ready()` registers `check_iiif_profiles`, a system check that validates `IIIF_PROFILES` at startup (ids `djiiif.W001`/`E001`/`E002`/`E003`). Callable and `Profile` entries pass unchecked (a callable's shape is only knowable at call time).
 - `djiiif/templatetags/iiiftags.py` — registers the `{% iiif imagefield 'profile' %}` template tag. The tag just does `getattr(imagefield.iiif, profile)`, so it delegates to the real `IIIFObject` via `IIIFFieldFile.iiif`.
 - `djiiif/templatetags/__init__.py` — **dead code**: contains an out-of-sync duplicate of `IIIFObject` / `IIIFField` / `urljoin`. Nothing imports it. Treat `djiiif/__init__.py` as the source of truth; this file should be emptied as part of cleanup.
@@ -96,7 +98,9 @@ Every change to `djiiif/` must keep the suite green and the coverage gate satisf
 - `info_document`: the default (v3) and `IIIF_IMAGE_API_VERSION=2` document shapes, the `IIIF_COMPLIANCE_LEVEL` override, `None` for an empty field, the `ImproperlyConfigured` unknown-version path, and that `.info` (the URL) is unchanged alongside it.
 - `Profile`: the 3.0 defaults, the `mirror`/`upscale` prefix folding (including the no-double-prefix guards), and that a `Profile` works as an `IIIF_PROFILES` entry; `resolve_profile` for dict/`Profile`/callable inputs plus its two `ImproperlyConfigured` rejection paths.
 - `manifest`: the Presentation-3.0 top-level shape, the nested canvas/image body, the `ImageService2` (v2) variant, and `None` for an empty field.
-- The `serve_info_json` view: the happy path (document body, `application/ld+json`, CORS header) and its `Http404` paths (missing file, non-image).
+- `as_dict`: the profile mapping, the `include_meta=True` extras, and the empty-field (`""`) case.
+- The `serve_info_json` and `serve_manifest` views: the happy path (document body, `application/ld+json`, CORS header) and their `Http404` paths (missing file, non-image).
+- `IIIFSerializerField` (when DRF is installed): the serialized mapping, the `include_meta` variant, and the read-only default. The test module must `importorskip("rest_framework")` so the suite still passes without the `drf` extra.
 - `check_iiif_profiles`: valid profiles pass; the `W001` (unset), `E001` (non-dict), `E002` (bad type), and `E003` (missing keys) paths each fire.
 - The empty-`IIIF_PROFILES` path must not raise (`info`/`identifier` are `""`, documents are `None`).
 

--- a/README.md
+++ b/README.md
@@ -188,9 +188,9 @@ return JsonResponse(asset.original.iiif.manifest)
 
 Like `info_document`, it reads the image's dimensions from storage and returns `None` for an empty field. The manifest is always Presentation 3.0; its embedded image service follows `IIIF_IMAGE_API_VERSION` (`ImageService3` by default, `ImageService2` when set to `2`).
 
-### Serving info.json from Django
+### Serving info.json and manifests from Django
 
-djiiif can also serve `info.json` itself — no separate image server is required for the metadata document. Include its URLconf:
+djiiif can also serve the `info.json` and `manifest` documents itself — no separate image server is required for the metadata. Include its URLconf:
 
 ```python
 from django.urls import include, path
@@ -200,9 +200,44 @@ urlpatterns = [
 ]
 ```
 
-An image stored as `uploads/photo.jpg` is then served at `/iiif/uploads%2Fphoto.jpg/info.json`, with the `application/ld+json` content type and the CORS header IIIF clients expect. The document's `id` is derived from the request URL, so it always matches where it is served from. The view uses the default storage backend and reads image dimensions on demand.
+An image stored as `uploads/photo.jpg` is then served at `/iiif/uploads%2Fphoto.jpg/info.json` and `/iiif/uploads%2Fphoto.jpg/manifest`, each with the `application/ld+json` content type and the CORS header IIIF clients expect. Each document's `id` is derived from the request URL, so it always matches where it is served from. The views use the default storage backend and read image dimensions on demand.
 
 > Serving identifiers that contain encoded slashes requires your web server to allow encoded slashes in the path (e.g. Apache's `AllowEncodedSlashes On`); flat identifiers need no such configuration.
+
+### All profiles as a dict (`as_dict`)
+
+`iiif.as_dict()` returns every profile URL keyed by profile name — handy for iterating in a template or building a JSON response:
+
+```python
+print(instance.original.iiif.as_dict())
+> {"thumbnail": "http://server/uploads%2Ffilename.jpg/full/150,/0/default.jpg"}
+```
+
+Pass `include_meta=True` to also include the `info` and `identifier` URLs. For an empty field every value is `""`.
+
+### Django REST Framework support
+
+An optional serializer field is available for [DRF](https://www.django-rest-framework.org/) projects. Install the extra:
+
+```
+pip install djiiif[drf]
+```
+
+Then serialize an `IIIFField` to its profile URLs (the `as_dict()` mapping):
+
+```python
+from rest_framework import serializers
+from djiiif.serializers import IIIFSerializerField
+
+class AssetSerializer(serializers.ModelSerializer):
+    original = IIIFSerializerField()          # or IIIFSerializerField(include_meta=True)
+
+    class Meta:
+        model = Asset
+        fields = ["id", "original"]
+```
+
+The field is read-only and emits `{"thumbnail": "…", …}`. Importing `djiiif` itself never imports DRF, so the core package stays dependency-free.
 
 ### Validating your configuration
 

--- a/djiiif/__init__.py
+++ b/djiiif/__init__.py
@@ -397,6 +397,10 @@ class IIIFObject(object):
         """
         self._parent = parent
 
+        # Remember the configured profile names (in order) so as_dict() can
+        # collect their URLs without re-reading settings.
+        self._profile_names = list(settings.IIIF_PROFILES)
+
         # Encode the identifier once; it is shared by every URL below. Empty for
         # an unset field, which drives the empty-string branch throughout.
         identifier = encode_identifier(parent.name) if parent.name else ""
@@ -419,6 +423,26 @@ class IIIFObject(object):
         else:
             self.info = ""
             self.identifier = ""
+
+    def as_dict(self, *, include_meta: bool = False) -> dict[str, str]:
+        """Return the profile URLs as a plain ``dict``, keyed by profile name.
+
+        Handy for JSON APIs (see :mod:`djiiif.serializers`) and for iterating
+        profiles in a template. For an empty/unset field every value is ``""``.
+
+        Args:
+            include_meta: When true, also include the ``info`` and ``identifier``
+                URLs under those keys.
+
+        Returns:
+            A ``{profile_name: url}`` mapping, optionally with ``info`` and
+            ``identifier`` entries appended.
+        """
+        data = {name: getattr(self, name) for name in self._profile_names}
+        if include_meta:
+            data["info"] = self.info
+            data["identifier"] = self.identifier
+        return data
 
     @cached_property
     def info_document(self) -> dict | None:

--- a/djiiif/serializers.py
+++ b/djiiif/serializers.py
@@ -1,0 +1,58 @@
+"""Optional Django REST Framework support for :class:`~djiiif.IIIFField`.
+
+This module imports ``rest_framework``, which djiiif does not depend on at
+runtime. Install the extra to use it::
+
+    pip install djiiif[drf]
+
+Importing :mod:`djiiif` itself never imports this module, so the core package
+has no DRF dependency.
+"""
+
+from rest_framework import serializers
+
+
+class IIIFSerializerField(serializers.Field):
+    """A read-only DRF field that serializes an ``IIIFField`` to its profile URLs.
+
+    Declare it on a serializer with the model's IIIF field as the source::
+
+        class AssetSerializer(serializers.ModelSerializer):
+            original = IIIFSerializerField()
+
+            class Meta:
+                model = Asset
+                fields = ["id", "original"]
+
+    The representation is :meth:`djiiif.IIIFObject.as_dict`, i.e. a
+    ``{profile_name: url}`` mapping (with ``info``/``identifier`` included when
+    ``include_meta`` is set).
+
+    Attributes:
+        include_meta: Passed through to ``as_dict`` to include the ``info`` and
+            ``identifier`` URLs.
+    """
+
+    def __init__(self, *args, include_meta: bool = False, **kwargs):
+        """Configure the field.
+
+        Args:
+            include_meta: Include the ``info``/``identifier`` URLs in the output.
+            *args: Forwarded to ``serializers.Field``.
+            **kwargs: Forwarded to ``serializers.Field``; ``read_only`` defaults
+                to ``True`` since the representation is derived, not writable.
+        """
+        self.include_meta = include_meta
+        kwargs.setdefault("read_only", True)
+        super().__init__(*args, **kwargs)
+
+    def to_representation(self, value) -> dict[str, str]:
+        """Serialize an ``IIIFFieldFile`` to its profile URL mapping.
+
+        Args:
+            value: The ``IIIFFieldFile`` attribute value for the source field.
+
+        Returns:
+            The ``{profile_name: url}`` mapping from ``value.iiif.as_dict``.
+        """
+        return value.iiif.as_dict(include_meta=self.include_meta)

--- a/djiiif/urls.py
+++ b/djiiif/urls.py
@@ -1,21 +1,24 @@
-"""URL patterns for the built-in ``info.json`` serving view.
+"""URL patterns for the built-in IIIF document views.
 
-Include this in a project's URLconf to expose ``info.json`` for stored images::
+Include this in a project's URLconf to expose ``info.json`` and ``manifest`` for
+stored images::
 
     path("iiif/", include("djiiif.urls")),
 
 An image stored as ``uploads/photo.jpg`` is then served at
-``/iiif/uploads%2Fphoto.jpg/info.json``. Serving identifiers that contain
-encoded slashes requires the web server to allow encoded slashes in the path
-(e.g. Apache's ``AllowEncodedSlashes``); flat identifiers need no such config.
+``/iiif/uploads%2Fphoto.jpg/info.json`` and
+``/iiif/uploads%2Fphoto.jpg/manifest``. Serving identifiers that contain encoded
+slashes requires the web server to allow encoded slashes in the path (e.g.
+Apache's ``AllowEncodedSlashes``); flat identifiers need no such config.
 """
 
 from django.urls import re_path
 
-from djiiif.views import serve_info_json
+from djiiif.views import serve_info_json, serve_manifest
 
 app_name = "djiiif"
 
 urlpatterns = [
     re_path(r"^(?P<identifier>.+)/info\.json$", serve_info_json, name="info-json"),
+    re_path(r"^(?P<identifier>.+)/manifest$", serve_manifest, name="manifest"),
 ]

--- a/djiiif/views.py
+++ b/djiiif/views.py
@@ -1,10 +1,12 @@
-"""A drop-in view that serves a IIIF Image API ``info.json`` from storage.
+"""Drop-in views that serve IIIF documents for stored images.
 
 Mounting :data:`djiiif.urls.urlpatterns` turns a Django instance into a minimal
-level-0 ``info.json`` provider: the view maps an identifier back to a stored
-image, reads its dimensions, and returns the document built by
-:func:`djiiif.build_info_document`. It does not serve derivative pixels — only
-the ``info.json`` metadata document.
+provider of two documents built from a stored image: an Image API ``info.json``
+(:func:`serve_info_json`) and a Presentation API ``manifest``
+(:func:`serve_manifest`). Each maps an identifier back to a stored image, reads
+its dimensions, and returns the document built by the corresponding
+:mod:`djiiif` builder. Neither serves derivative pixels — only the JSON
+documents.
 """
 
 from urllib.parse import unquote
@@ -14,25 +16,18 @@ from django.core.files.images import get_image_dimensions
 from django.core.files.storage import default_storage
 from django.http import Http404, JsonResponse
 
-from djiiif import build_info_document
+from djiiif import build_info_document, build_manifest
 
 
-def serve_info_json(request, identifier):
-    """Serve the ``info.json`` document for a stored image.
-
-    The ``identifier`` captured from the URL is percent-decoded back into the
-    storage name, opened via ``default_storage``, and measured. The document's
-    ``id`` is taken from the request URL (minus the ``/info.json`` suffix) so it
-    always matches the URL the document is served from, as the spec requires.
+def _load_dimensions(identifier: str) -> tuple[str, int, int]:
+    """Resolve an encoded identifier to its storage name and pixel dimensions.
 
     Args:
-        request: The incoming ``HttpRequest``.
         identifier: The encoded identifier segment captured by the URLconf.
 
     Returns:
-        A ``JsonResponse`` carrying the ``info.json`` document, with the
-        ``application/ld+json`` content type and a permissive CORS header that
-        IIIF clients require.
+        A ``(name, width, height)`` tuple, where ``name`` is the decoded storage
+        name.
 
     Raises:
         Http404: If the file is missing, outside storage, or not a readable
@@ -53,13 +48,65 @@ def serve_info_json(request, identifier):
     if not width or not height:
         raise Http404("Identifier does not resolve to a readable image.")
 
-    # The document id must equal the base URI it is served from (the request URL
-    # without the trailing "/info.json").
-    id_url = request.build_absolute_uri(request.path).rsplit("/info.json", 1)[0]
+    return name, width, height
 
-    response = JsonResponse(
-        build_info_document(id_url, width, height),
-        content_type="application/ld+json",
-    )
+
+def _ld_json(document: dict) -> JsonResponse:
+    """Wrap a document in a JSON-LD response with the IIIF CORS header.
+
+    Args:
+        document: The IIIF document to serialize.
+
+    Returns:
+        A ``JsonResponse`` with the ``application/ld+json`` content type and a
+        permissive ``Access-Control-Allow-Origin`` header that IIIF clients
+        require.
+    """
+    response = JsonResponse(document, content_type="application/ld+json")
     response["Access-Control-Allow-Origin"] = "*"
     return response
+
+
+def serve_info_json(request, identifier):
+    """Serve the ``info.json`` document for a stored image.
+
+    The document's ``id`` is taken from the request URL (minus the
+    ``/info.json`` suffix) so it always matches the URL the document is served
+    from, as the spec requires.
+
+    Args:
+        request: The incoming ``HttpRequest``.
+        identifier: The encoded identifier segment captured by the URLconf.
+
+    Returns:
+        A JSON-LD ``JsonResponse`` carrying the ``info.json`` document.
+
+    Raises:
+        Http404: If the identifier does not resolve to a readable image.
+    """
+    _name, width, height = _load_dimensions(identifier)
+    id_url = request.build_absolute_uri(request.path).rsplit("/info.json", 1)[0]
+    return _ld_json(build_info_document(id_url, width, height))
+
+
+def serve_manifest(request, identifier):
+    """Serve a single-image Presentation API manifest for a stored image.
+
+    The image service base URI is the request URL minus the ``/manifest``
+    suffix, matching the identifier the ``info.json`` view serves. The manifest
+    label defaults to the file's base name.
+
+    Args:
+        request: The incoming ``HttpRequest``.
+        identifier: The encoded identifier segment captured by the URLconf.
+
+    Returns:
+        A JSON-LD ``JsonResponse`` carrying the manifest document.
+
+    Raises:
+        Http404: If the identifier does not resolve to a readable image.
+    """
+    name, width, height = _load_dimensions(identifier)
+    id_url = request.build_absolute_uri(request.path).rsplit("/manifest", 1)[0]
+    label = name.rsplit("/", 1)[-1]
+    return _ld_json(build_manifest(id_url, width, height, label=label))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,12 @@ addopts = "--cov=djiiif --cov-report=term-missing --cov-fail-under=90"
 [tool.coverage.run]
 branch = true
 source = ["djiiif"]
-omit = ["djiiif/templatetags/__init__.py"]
+omit = [
+    "djiiif/templatetags/__init__.py",
+    # Optional DRF extra: only importable/tested when djangorestframework is
+    # installed, so it must not gate core coverage.
+    "djiiif/serializers.py",
+]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,10 @@ setup(
 
     packages=find_packages(exclude=["tests", "tests.*"]),
     install_requires=['Django'],
+    extras_require={
+        # Optional Django REST Framework support (djiiif.serializers).
+        'drf': ['djangorestframework'],
+    },
     include_package_data=True,
     license='BSD License',  # example license
     description='Simple IIIF integration for Django.',

--- a/tests/test_iiif_object.py
+++ b/tests/test_iiif_object.py
@@ -145,3 +145,30 @@ def test_info_url_unchanged_alongside_document():
     # .info remains the external info.json URL, independent of .info_document.
     obj = IIIFObject(FakeParent("uploads/file.jpg", width=400, height=300))
     assert obj.info == "http://server/uploads%2Ffile.jpg/info.json"
+
+
+@override_settings(
+    IIIF_PROFILES={
+        "thumb": DICT_PROFILES["thumbnail"],
+        "square": _square_profile,
+    }
+)
+def test_as_dict_returns_profile_urls():
+    obj = IIIFObject(FakeParent("pic.jpg", width=100, height=200))
+    assert obj.as_dict() == {
+        "thumb": "http://server/pic.jpg/full/150,/0/default.jpg",
+        "square": "http://server/pic.jpg/0,0,100,200/256,256/0/default.jpg",
+    }
+
+
+@override_settings(IIIF_PROFILES=DICT_PROFILES)
+def test_as_dict_include_meta_adds_info_and_identifier():
+    obj = IIIFObject(FakeParent("uploads/file.jpg"))
+    data = obj.as_dict(include_meta=True)
+    assert data["info"] == "http://server/uploads%2Ffile.jpg/info.json"
+    assert data["identifier"] == "http://server/uploads%2Ffile.jpg"
+
+
+@override_settings(IIIF_PROFILES=DICT_PROFILES)
+def test_as_dict_empty_field_is_empty_strings():
+    assert IIIFObject(FakeParent("")).as_dict() == {"thumbnail": ""}

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,0 +1,42 @@
+"""Tests for the optional DRF serializer field.
+
+Skipped entirely when djangorestframework is not installed; CI installs the
+``drf`` extra so these run there.
+"""
+
+import pytest
+from django.test import override_settings
+
+pytest.importorskip("rest_framework")
+
+from djiiif import IIIFField, IIIFFieldFile  # noqa: E402
+from djiiif.serializers import IIIFSerializerField  # noqa: E402
+
+DICT_PROFILES = {
+    "thumbnail": {"host": "http://server/", "region": "full", "size": "150,",
+                  "rotation": "0", "quality": "default", "format": "jpg"},
+}
+
+
+def _field_file(name):
+    return IIIFFieldFile(instance=None, field=IIIFField(), name=name)
+
+
+@override_settings(IIIF_PROFILES=DICT_PROFILES)
+def test_field_serializes_profile_urls():
+    field = IIIFSerializerField()
+    assert field.to_representation(_field_file("uploads/x.jpg")) == {
+        "thumbnail": "http://server/uploads%2Fx.jpg/full/150,/0/default.jpg",
+    }
+
+
+@override_settings(IIIF_PROFILES=DICT_PROFILES)
+def test_field_include_meta_adds_info_and_identifier():
+    field = IIIFSerializerField(include_meta=True)
+    data = field.to_representation(_field_file("uploads/x.jpg"))
+    assert data["info"] == "http://server/uploads%2Fx.jpg/info.json"
+    assert data["identifier"] == "http://server/uploads%2Fx.jpg"
+
+
+def test_field_is_read_only_by_default():
+    assert IIIFSerializerField().read_only is True

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -57,3 +57,25 @@ def test_serve_info_json_404_when_not_an_image(monkeypatch, rf):
     _patch(monkeypatch, dimensions=(None, None))
     with pytest.raises(Http404):
         views.serve_info_json(rf.get("/iiif/x.txt/info.json"), "x.txt")
+
+
+def test_serve_manifest_returns_document(monkeypatch, rf):
+    _patch(monkeypatch, dimensions=(4000, 3000))
+    request = rf.get("/iiif/photo.jpg/manifest")
+
+    response = views.serve_manifest(request, "photo.jpg")
+
+    assert response["Content-Type"] == "application/ld+json"
+    assert response["Access-Control-Allow-Origin"] == "*"
+    body = json.loads(response.content)
+    assert body["type"] == "Manifest"
+    assert body["id"] == "http://testserver/iiif/photo.jpg/manifest"
+    assert body["label"] == {"none": ["photo.jpg"]}
+    canvas = body["items"][0]
+    assert (canvas["width"], canvas["height"]) == (4000, 3000)
+
+
+def test_serve_manifest_404_when_missing(monkeypatch, rf):
+    _patch(monkeypatch, dimensions=(1, 1), open_raises=FileNotFoundError())
+    with pytest.raises(Http404):
+        views.serve_manifest(rf.get("/iiif/x.jpg/manifest"), "x.jpg")


### PR DESCRIPTION
## Summary

Brings the Tier-3 work from **#24** onto `master`. #24 was merged into its stacked base branch `iiif-3.0-support` moments *after* #23 had already merged `iiif-3.0-support`→`master`, so #24's commits never actually reached `master`. This PR carries that delta (nothing else — `master` already has everything from #23).

Contents (identical to the already-reviewed #24):
- `iiif.as_dict(include_meta=False)` — all profile URLs as a dict.
- `serve_manifest` view + `/manifest` URL (shared `_load_dimensions` / `_ld_json` helpers).
- Optional `IIIFSerializerField` via the `drf` extra; never imported by core.

## Test plan
- Already verified on #24: 62 passing, 100% coverage, `build` + `twine check` clean, `import djiiif` does not import DRF.
- No new changes here — this is purely the merge-ordering recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lxpygeu3FySmFqe3U92MJJ
