### PR TITLE
Fix docs version label on Read the Docs (fetch git tags)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,13 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.12"
+  jobs:
+    post_checkout:
+      # Read the Docs does a shallow clone without tags; fetch the full history
+      # and tags so setuptools-scm can derive the real version from the git tag
+      # (otherwise the version falls back to 0.1.dev and the docs mislabel it).
+      - git fetch --unshallow || true
+      - git fetch --tags || true
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
The published docs were labelled **"djiiif 0.1"** instead of the real version. Read the Docs shallow-clones the repo **without tags**, so `setuptools-scm` couldn't see `v1.0.0` and fell back to its `0.1.dev` default.

Adds a `post_checkout` job to `.readthedocs.yaml` that fetches the full history and tags, so the version resolves correctly (e.g. `1.0`). Verified against the live build: the `latest` docs otherwise render correctly at https://djiiif.readthedocs.io/en/latest/ — this only corrects the version string in the title/sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PVtZ3NHJAjz3DWfqf3URJ8