### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ dates are the commit dates of the corresponding version bump.
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-06
+
 ### Added
 - **navPlace extension (geolocated manifests) via GeoDjango.** A new opt-in
   `IIIF_NAVPLACE` setting — a callable (or dotted-path string) receiving the
@@ -222,7 +224,8 @@ changes from 0.24; the bump to 1.0 signals maturity, not a break.
   `IIIF_PROFILES`-driven profile URLs (dict and callable shapes), and the
   `{% iiif %}` template tag.
 
-[Unreleased]: https://github.com/rogerhoward/djiiif/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/rogerhoward/djiiif/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/rogerhoward/djiiif/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/rogerhoward/djiiif/compare/v0.24...v1.0.0
 [0.24]: https://github.com/rogerhoward/djiiif/compare/v0.23...v0.24
 [0.23]: https://github.com/rogerhoward/djiiif/compare/0.14...v0.23


### PR DESCRIPTION
Finalizes the `CHANGELOG` for the **1.1.0** release — renames `[Unreleased]` → `[1.1.0] - 2026-07-06`, opens a fresh `[Unreleased]`, and adds the compare links.

1.1.0 is a backwards-compatible **feature release** over 1.0.0 (no breaking changes, no MAJOR bump). It bundles the six new opt-in IIIF integrations added this cycle:

- **Content State 1.0** — shareable viewer deep links (`iiif.content_state`, `{% iiif_content_state %}`).
- **Presentation enrichment** — manifest descriptive metadata, multi-image manifests, Collections.
- **Change Discovery 1.0** — harvestable activity stream.
- **Web Annotations + Content Search 2.0** — transcriptions/OCR serving and search-within.
- **info.json enrichment** — declarative `IIIF_INFO` (`sizes`/`tiles`/limits/`rights`/…).
- **navPlace extension** — geolocated manifests via an optional GeoDjango bridge.

…plus a comprehensive **Read the Docs** documentation site.

Merging this, then tagging **`v1.1.0`**, drives `release.yml` (test → build → publish to PyPI via OIDC) and the versioned docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PVtZ3NHJAjz3DWfqf3URJ8